### PR TITLE
Changed symfony/form requirement to allow version 2.1 and up to 2.3-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "minimum-stability": "dev",
     "require": {
         "friendsofsymfony/user-bundle": "dev-master",
-        "symfony/form": "dev-master"
+        "symfony/form": ">=2.1,<2.3-dev"
     },
     "suggest": {
     },


### PR DESCRIPTION
It is not possible to use the bundle with symfony v.2.1 with the current composer requirement so I changed the symfony/form requirement to allow for v.2.1 and up to v2.3-dev
