### PR TITLE
Allow default data to be set when creating new registration forms

### DIFF
--- a/Controller/RegistrationManager.php
+++ b/Controller/RegistrationManager.php
@@ -55,7 +55,7 @@ class RegistrationManager
      * @param string $class
      * @return \Symfony\Component\HttpFoundation\RedirectResponse
      */
-    public function register($class)
+    public function register($class, $data = null)
     {
         $this->userDiscriminator->setClass($class);
         
@@ -71,7 +71,7 @@ class RegistrationManager
             $template = 'FOSUserBundle:Registration:register.html.'.$engine;
         }
         
-        $form = $this->formFactory->createForm();      
+        $form = $this->formFactory->createForm($data);      
         return $this->container->get('templating')->renderResponse($template, array(
             'form' => $form->createView(),
         ));

--- a/Form/FormFactory.php
+++ b/Form/FormFactory.php
@@ -48,7 +48,7 @@ class FormFactory implements FactoryInterface
      * 
      * @return \Symfony\Component\Form\Form 
      */
-    public function createForm()
+    public function createForm($data = null)
     {
         $type = $this->userDiscriminator->getFormType($this->type);
         $name = $this->userDiscriminator->getFormName($this->type);
@@ -61,7 +61,7 @@ class FormFactory implements FactoryInterface
         $form = $this->formFactory->createNamed(
                 $name, 
                 $type, 
-                null, 
+                $data, 
                 array('validation_groups' => $validationGroups));
         
         $this->forms[$name] = $form;


### PR DESCRIPTION
Not sure if this would be useful for anyone else, but I found my self in need of some default data before displaying the registration form.

Example:

$user = new User();
$user->setFirstName('Joe');

return
$this->container->get('pugx_multi_user.registration_manager')->register(
$class, $user);
