### PR TITLE
Updated "Overriding FOSUserBundle Forms" URL

### DIFF
--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -155,7 +155,7 @@ class UserTwo extends User
 ```
 
 You must also create forms for your entities:
-see [Overriding Default FOSUserBundle Forms] (https://github.com/FriendsOfSymfony/FOSUserBundle/blob/1.1.0/Resources/doc/overriding_forms.md)
+see [Overriding Default FOSUserBundle Forms] (https://github.com/josevillalobos/FOSUserBundle/blob/master/Resources/doc/overriding_forms.md)
 
 ### 4. Configure the FOSUserBundle (PUGXMultiUserBundle params)
 


### PR DESCRIPTION
Since it was pointing to an outdated documentation on FOSUserBundle and the code there was not working properly with actual version.
