### PR TITLE
remove fos_user.template.engine parameter

### DIFF
--- a/Controller/ProfileManager.php
+++ b/Controller/ProfileManager.php
@@ -63,8 +63,7 @@ class ProfileManager
 
         $template = $this->userDiscriminator->getTemplate('profile');
         if (is_null($template)) {
-            $engine = $this->container->getParameter('fos_user.template.engine');
-            $template = 'FOSUserBundle:Registration:edit.html.'.$engine;
+            $template = 'FOSUserBundle:Profile:edit.html.twig';
         }
 
         $form = $this->formFactory->createForm();

--- a/Controller/RegistrationManager.php
+++ b/Controller/RegistrationManager.php
@@ -69,8 +69,7 @@ class RegistrationManager
         
         $template = $this->userDiscriminator->getTemplate('registration');
         if (is_null($template)) {
-            $engine = $this->container->getParameter('fos_user.template.engine');
-            $template = 'FOSUserBundle:Registration:register.html.'.$engine;
+            $template = 'FOSUserBundle:Registration:register.html.twig';
         }
         
         $form = $this->formFactory->createForm();      

--- a/Tests/Controller/RegistrationManagerTest.php
+++ b/Tests/Controller/RegistrationManagerTest.php
@@ -89,12 +89,6 @@ class RegistrationManagerTest extends \PHPUnit_Framework_TestCase
                 ->with('registration')
                 ->will($this->returnValue(null));
         
-        $this->container
-                ->expects($this->at(1))
-                ->method('getParameter')
-                ->with('fos_user.template.engine')
-                ->will($this->returnValue('twig'));
-        
         $this->formFactory
                 ->expects($this->exactly(1))
                 ->method('createForm')

--- a/Tests/Controller/RegistrationManagerTest.php
+++ b/Tests/Controller/RegistrationManagerTest.php
@@ -95,7 +95,7 @@ class RegistrationManagerTest extends \PHPUnit_Framework_TestCase
                 ->will($this->returnValue($this->form));
         
         $this->container
-                ->expects($this->at(2))
+                ->expects($this->at(1))
                 ->method('get')
                 ->with('templating')
                 ->will($this->returnValue($this->twig));


### PR DESCRIPTION
Hey there

This request contains the following changes:
* The parameter `fos_user.template.engine` does no longer exists due to [this pull request](https://github.com/FriendsOfSymfony/FOSUserBundle/pull/1613) in FOSUserBundle.
*  And I think the used template in `ProfileManager` should be `FOSUserBundle:Profile:edit.html.twig` instead of `FOSUserBundle:Registration:edit.html.twig`.

Best regards from Switzerland,
binzram