### PR TITLE
Add form options, controller template arrays

### DIFF
--- a/Controller/ProfileManager.php
+++ b/Controller/ProfileManager.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PUGX\MultiUserBundle\Controller;
 
 use FOS\UserBundle\Controller\ProfileController;
@@ -30,10 +31,10 @@ class ProfileManager
     protected $formFactory;
 
     /**
-     * @param UserDiscriminator $userDiscriminator
+     * @param UserDiscriminator  $userDiscriminator
      * @param ContainerInterface $container
-     * @param ProfileController $controller
-     * @param FormFactory $formFactory
+     * @param ProfileController  $controller
+     * @param FormFactory        $formFactory
      */
     public function __construct(
         UserDiscriminator $userDiscriminator,
@@ -49,16 +50,17 @@ class ProfileManager
 
     /**
      * @param string $class
+     *
      * @return RedirectResponse
      */
-    public function edit($class)
+    public function edit($class, $templates = array())
     {
         $this->userDiscriminator->setClass($class);
 
         $this->controller->setContainer($this->container);
         $result = $this->controller->editAction($this->container->get('request'));
         if ($result instanceof RedirectResponse) {
-            return $this->controller->redirect($this->controller->get('request')->getRequestUri());
+            return $result;
         }
 
         $template = $this->userDiscriminator->getTemplate('profile');
@@ -67,8 +69,11 @@ class ProfileManager
         }
 
         $form = $this->formFactory->createForm();
-        return $this->container->get('templating')->renderResponse($template, array(
-            'form' => $form->createView(),
+
+        return $this->container->get('templating')->renderResponse($template,
+                array(
+                'form' => $form->createView(),
+                'templates' => $templates,
         ));
     }
 }

--- a/Controller/RegistrationManager.php
+++ b/Controller/RegistrationManager.php
@@ -11,38 +11,33 @@ use PUGX\MultiUserBundle\Form\FormFactory;
 class RegistrationManager
 {
     /**
-     *
-     * @var \PUGX\MultiUserBundle\Model\UserDiscriminator 
+     * @var \PUGX\MultiUserBundle\Model\UserDiscriminator
      */
     protected $userDiscriminator;
-    
+
     /**
-     *
-     * @var \Symfony\Component\DependencyInjection\ContainerInterface 
+     * @var \Symfony\Component\DependencyInjection\ContainerInterface
      */
     protected $container;
-    
+
     /**
-     *
-     * @var \FOS\UserBundle\Controller\RegistrationController 
+     * @var \FOS\UserBundle\Controller\RegistrationController
      */
     protected $controller;
-    
+
     /**
-     *
      * @var \PUGX\MultiUserBundle\Form\FormFactory
      */
     protected $formFactory;
-        
+
     /**
-     * 
-     * @param \PUGX\MultiUserBundle\Model\UserDiscriminator $userDiscriminator
+     * @param \PUGX\MultiUserBundle\Model\UserDiscriminator             $userDiscriminator
      * @param \Symfony\Component\DependencyInjection\ContainerInterface $container
-     * @param \FOS\UserBundle\Controller\RegistrationController $controller
-     * @param \PUGX\MultiUserBundle\Form\FormFactory $formFactory
+     * @param \FOS\UserBundle\Controller\RegistrationController         $controller
+     * @param \PUGX\MultiUserBundle\Form\FormFactory                    $formFactory
      */
     public function __construct(UserDiscriminator $userDiscriminator,
-                                ContainerInterface $container, 
+                                ContainerInterface $container,
                                 RegistrationController $controller,
                                 FormFactory $formFactory)
     {
@@ -51,30 +46,32 @@ class RegistrationManager
         $this->controller = $controller;
         $this->formFactory = $formFactory;
     }
-    
+
     /**
-     * 
      * @param string $class
+     *
      * @return \Symfony\Component\HttpFoundation\RedirectResponse
      */
-    public function register($class)
+    public function register($class, $templates = array())
     {
         $this->userDiscriminator->setClass($class);
-        
+
         $this->controller->setContainer($this->container);
-        $result = $this->controller->registerAction($this->container->get('request'));        
+        $result = $this->controller->registerAction($this->container->get('request'));
         if ($result instanceof RedirectResponse) {
             return $result;
         }
-        
+
         $template = $this->userDiscriminator->getTemplate('registration');
         if (is_null($template)) {
             $template = 'FOSUserBundle:Registration:register.html.twig';
         }
-        
-        $form = $this->formFactory->createForm();      
+
+        $form = $this->formFactory->createForm();
+
         return $this->container->get('templating')->renderResponse($template, array(
             'form' => $form->createView(),
+            'templates' => $templates,
         ));
     }
 }

--- a/DependencyInjection/Compiler/OverrideServiceCompilerPass.php
+++ b/DependencyInjection/Compiler/OverrideServiceCompilerPass.php
@@ -18,6 +18,16 @@ class OverrideServiceCompilerPass implements CompilerPassInterface
                 $container, 
                 'fos_user.profile.form.factory', 
                 'pugx_multi_user.profile_form_factory');
+
+        $this->changeService(
+                $container,
+                'fos_user.registration.form.type',
+                'pugx_multi_user.registration.form.type');
+
+        $this->changeService(
+                $container,
+                'fos_user.profile.form.type',
+                'pugx_multi_user.profile.form.type');
     }
     
     private function changeService($container, $serviceName, $newServiceName)

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -81,7 +81,11 @@ class Configuration implements ConfigurationInterface
                                  ->end()
                             ->end()
                         ->end()
-                        
+                        ->children()
+                            ->arrayNode('options')
+                                ->prototype('scalar')->defaultValue(null)->end()
+                            ->end()
+                        ->end()
                     ->end()
                 ->end()
                 ->end();

--- a/Form/ProfileFormType.php
+++ b/Form/ProfileFormType.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\UserBundle\Form\Type;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\Security\Core\Validator\Constraints\UserPassword;
+
+class ProfileFormType extends AbstractType
+{
+    private $class;
+    protected $options;
+
+    /**
+     * @param string $class The User class name
+     */
+    public function __construct($class, $options = null)
+    {
+        $this->class = $class;
+        $this->options = $options;
+    }
+
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $this->buildUserForm($builder, $options);
+
+        $builder->add('current_password', 'password', array(
+            'label' => 'form.current_password',
+            'translation_domain' => 'FOSUserBundle',
+            'mapped' => false,
+            'constraints' => new UserPassword(),
+        ));
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults(array(
+            'data_class' => $this->class,
+            'intention'  => 'profile',
+        ));
+    }
+
+    // BC for SF < 2.7
+    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    {
+        $this->configureOptions($resolver);
+    }
+
+    public function getName()
+    {
+        return 'fos_user_profile';
+    }
+
+    /**
+     * Builds the embedded form representing the user.
+     *
+     * @param FormBuilderInterface $builder
+     * @param array                $options
+     */
+    protected function buildUserForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('username', null, array('label' => 'form.username', 'translation_domain' => 'FOSUserBundle'))
+            ->add('email', 'email', array('label' => 'form.email', 'translation_domain' => 'FOSUserBundle'))
+        ;
+    }
+}

--- a/Form/ProfileFormType.php
+++ b/Form/ProfileFormType.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace FOS\UserBundle\Form\Type;
+namespace PUGX\MultiUserBundle\Form;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -19,7 +19,7 @@ use Symfony\Component\Security\Core\Validator\Constraints\UserPassword;
 
 class ProfileFormType extends AbstractType
 {
-    private $class;
+    protected $class;
     protected $options;
 
     /**
@@ -47,7 +47,7 @@ class ProfileFormType extends AbstractType
     {
         $resolver->setDefaults(array(
             'data_class' => $this->class,
-            'intention'  => 'profile',
+            'intention' => 'profile',
         ));
     }
 

--- a/Form/RegistrationFormType.php
+++ b/Form/RegistrationFormType.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PUGX\MultiUserBundle\Form;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+
+class RegistrationFormType extends AbstractType
+{
+    private $class;
+    protected $options;
+
+    /**
+     * @param string $class The User class name
+     */
+    public function __construct($class, $options = null)
+    {
+        $this->class = $class;
+        $this->options = $options;
+    }
+
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('email', 'email', array('label' => 'form.email', 'translation_domain' => 'FOSUserBundle'))
+            ->add('username', null, array('label' => 'form.username', 'translation_domain' => 'FOSUserBundle'))
+            ->add('plainPassword', 'repeated', array(
+                'type' => 'password',
+                'options' => array('translation_domain' => 'FOSUserBundle'),
+                'first_options' => array('label' => 'form.password'),
+                'second_options' => array('label' => 'form.password_confirmation'),
+                'invalid_message' => 'fos_user.password.mismatch',
+            ))
+        ;
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults(array(
+            'data_class' => $this->class,
+            'intention'  => 'registration',
+        ));
+    }
+
+    // BC for SF < 2.7
+    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    {
+        $this->configureOptions($resolver);
+    }
+
+    public function getName()
+    {
+        return 'fos_user_registration';
+    }
+
+
+}

--- a/Model/UserDiscriminator.php
+++ b/Model/UserDiscriminator.php
@@ -71,7 +71,7 @@ class UserDiscriminator
         foreach ($this->conf as $entity => $conf) {
             $classes[] = $entity;
         }
-        
+
         return $classes;
     }
         
@@ -147,13 +147,13 @@ class UserDiscriminator
     {
         $class = $this->getClass();
         $className = $this->conf[$class][$name]['form']['type'];
+        $options = $this->conf[$class]['options'];
         
         if (!class_exists($className)) {
             throw new \InvalidArgumentException(sprintf('UserDiscriminator, error getting form type : "%s" not found', $className));
         }
 
-        $type = new $className($class);
-        
+        $type = new $className($class, $options);
         return $type;
     }
     
@@ -185,7 +185,7 @@ class UserDiscriminator
     {
         return $this->conf[$this->getClass()][$name]['template'];
     }
-    
+
     /**
      *
      * @param array $entities
@@ -219,7 +219,8 @@ class UserDiscriminator
                             'validation_groups' => $user['profile']['form']['validation_groups'],
                         ),
                         'template' => $user['profile']['template'],
-                    )
+                    ),
+                    'options' => $user['options']
                 );
         }
     }

--- a/Model/UserDiscriminator.php
+++ b/Model/UserDiscriminator.php
@@ -136,6 +136,18 @@ class UserDiscriminator
     {
         return $this->conf[$this->getClass()]['factory'];
     }
+
+    /**
+     *
+     * @return array
+     */
+    public function getUserOptions()
+    {
+        $class = $this->getClass();
+        $options = $this->conf[$class]['options'];
+
+        return $options;
+    }
     
     /**
      * 

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -47,4 +47,15 @@ services:
     # alias
     pugx_user_discriminator:
         alias: pugx_user.manager.user_discriminator
-    
+
+    pugx_multi_user.registration.form.type:
+        class: PUGX\MultiUserBundle\Form\RegistrationFormType
+        arguments: [%fos_user.model.user.class%]
+        tags:
+            - { name: form.type, alias: fos_user_registration }        
+
+    pugx_multi_user.profile.form.type:
+        class: PUGX\MultiUserBundle\Form\ProfileFormType
+        arguments: [%fos_user.model.user.class%]
+        tags:
+            - { name: form.type, alias: fos_user_profile }        

--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -23,7 +23,8 @@ This version of the bundle requires Symfony dev-master and FOSUserBundle dev-mas
 4. Configure the FOSUserBundle (PUGXMultiUserBundle params)
 5. Configure parameters for UserDiscriminator
 6. Create your controllers
-7. Using the User Manager
+7. Overriding forms
+8. Using the User Manager
 
 
 ### 1. Download PUGXMultiUserBundle
@@ -33,19 +34,19 @@ This version of the bundle requires Symfony dev-master and FOSUserBundle dev-mas
 Add the following lines in your composer.json:
 
 ```
-{
-    "require": {
-        "friendsofsymfony/user-bundle": "2.0.*@dev",
-        "pugx/multi-user-bundle": "3.0.*@dev"
+    {
+        "require": {
+            "friendsofsymfony/user-bundle": "2.0.*@dev",
+            "pugx/multi-user-bundle": "3.0.*@dev"
+        }
     }
-}
 
 ```
 
 Now, run the composer to download the bundle:
 
 ``` bash
-$ php composer.phar update pugx/multi-user-bundle
+    $ php composer.phar update pugx/multi-user-bundle
 ```
 
 
@@ -54,17 +55,17 @@ $ php composer.phar update pugx/multi-user-bundle
 Enable the bundles in the kernel:
 
 ``` php
-<?php
-// app/AppKernel.php
-
-public function registerBundles()
-{
-    $bundles = array(
-        // ...
-        new PUGX\MultiUserBundle\PUGXMultiUserBundle(),
-        new FOS\UserBundle\FOSUserBundle(),
-    );
-}
+    <?php
+    // app/AppKernel.php
+    
+    public function registerBundles()
+    {
+        $bundles = array(
+            // ...
+            new PUGX\MultiUserBundle\PUGXMultiUserBundle(),
+            new FOS\UserBundle\FOSUserBundle(),
+        );
+    }
 ```
 
 ### 3. Create your Entities
@@ -74,84 +75,84 @@ Create entities using Doctrine2 inheritance.
 Abstract User that directly extends the model FOS\UserBundle\Model\User
 
 ``` php
-<?php
-
-namespace Acme\UserBundle\Entity;
-
-use Doctrine\ORM\Mapping as ORM;
-use FOS\UserBundle\Model\User as BaseUser;
-
-/**
- * @ORM\Entity
- * @ORM\Table(name="user")
- * @ORM\InheritanceType("JOINED")
- * @ORM\DiscriminatorColumn(name="type", type="string")
- * @ORM\DiscriminatorMap({"user_one" = "UserOne", "user_two" = "UserTwo"})
- *
- */
-abstract class User extends BaseUser
-{
+    <?php
+    
+    namespace Acme\UserBundle\Entity;
+    
+    use Doctrine\ORM\Mapping as ORM;
+    use FOS\UserBundle\Model\User as BaseUser;
+    
     /**
-     * @ORM\Id
-     * @ORM\Column(type="integer")
-     * @ORM\GeneratedValue(strategy="AUTO")
+     * @ORM\Entity
+     * @ORM\Table(name="user")
+     * @ORM\InheritanceType("JOINED")
+     * @ORM\DiscriminatorColumn(name="type", type="string")
+     * @ORM\DiscriminatorMap({"user_one" = "UserOne", "user_two" = "UserTwo"})
+     *
      */
-    protected $id;
-}
+    abstract class User extends BaseUser
+    {
+        /**
+         * @ORM\Id
+         * @ORM\Column(type="integer")
+         * @ORM\GeneratedValue(strategy="AUTO")
+         */
+        protected $id;
+    }
 ```
 
 UserOne
 
 ``` php
-<?php
-
-namespace Acme\UserBundle\Entity;
-
-use Doctrine\ORM\Mapping as ORM;
-use PUGX\MultiUserBundle\Validator\Constraints\UniqueEntity;
-
-/**
- * @ORM\Entity
- * @ORM\Table(name="user_one")
- * @UniqueEntity(fields = "username", targetClass = "Acme\UserBundle\Entity\User", message="fos_user.username.already_used")
- * @UniqueEntity(fields = "email", targetClass = "Acme\UserBundle\Entity\User", message="fos_user.email.already_used")
- */
-class UserOne extends User
-{
+    <?php
+    
+    namespace Acme\UserBundle\Entity;
+    
+    use Doctrine\ORM\Mapping as ORM;
+    use PUGX\MultiUserBundle\Validator\Constraints\UniqueEntity;
+    
     /**
-     * @ORM\Id
-     * @ORM\Column(type="integer")
-     * @ORM\GeneratedValue(strategy="AUTO")
+     * @ORM\Entity
+     * @ORM\Table(name="user_one")
+     * @UniqueEntity(fields = "username", targetClass = "Acme\UserBundle\Entity\User", message="fos_user.username.already_used")
+     * @UniqueEntity(fields = "email", targetClass = "Acme\UserBundle\Entity\User", message="fos_user.email.already_used")
      */
-    protected $id;
-}
+    class UserOne extends User
+    {
+        /**
+         * @ORM\Id
+         * @ORM\Column(type="integer")
+         * @ORM\GeneratedValue(strategy="AUTO")
+         */
+        protected $id;
+    }
 ```
 
 UserTwo
 
 ``` php
-<?php
-
-namespace Acme\UserBundle\Entity;
-
-use Doctrine\ORM\Mapping as ORM;
-use PUGX\MultiUserBundle\Validator\Constraints\UniqueEntity;
-
-/**
- * @ORM\Entity
- * @ORM\Table(name="user_two")
- * @UniqueEntity(fields = "username", targetClass = "Acme\UserBundle\Entity\User", message="fos_user.username.already_used")
- * @UniqueEntity(fields = "email", targetClass = "Acme\UserBundle\Entity\User", message="fos_user.email.already_used")
- */
-class UserTwo extends User
-{
+    <?php
+    
+    namespace Acme\UserBundle\Entity;
+    
+    use Doctrine\ORM\Mapping as ORM;
+    use PUGX\MultiUserBundle\Validator\Constraints\UniqueEntity;
+    
     /**
-     * @ORM\Id
-     * @ORM\Column(type="integer")
-     * @ORM\GeneratedValue(strategy="AUTO")
+     * @ORM\Entity
+     * @ORM\Table(name="user_two")
+     * @UniqueEntity(fields = "username", targetClass = "Acme\UserBundle\Entity\User", message="fos_user.username.already_used")
+     * @UniqueEntity(fields = "email", targetClass = "Acme\UserBundle\Entity\User", message="fos_user.email.already_used")
      */
-    protected $id;
-}
+    class UserTwo extends User
+    {
+        /**
+         * @ORM\Id
+         * @ORM\Column(type="integer")
+         * @ORM\GeneratedValue(strategy="AUTO")
+         */
+        protected $id;
+    }
 ```
 
 You must also create forms for your entities:
@@ -164,13 +165,13 @@ but it does it only in controllers and forms handlers; in the other cases (comma
 it still uses the user_class configured in the config.
 
 ``` yaml
-# Acme/UserBundle/Resources/config/config.yml
-fos_user:
-    db_driver: orm
-    firewall_name: main
-    user_class: Acme\UserBundle\Entity\User
-    service:
-        user_manager: pugx_user_manager
+    # Acme/UserBundle/Resources/config/config.yml
+    fos_user:
+        db_driver: orm
+        firewall_name: main
+        user_class: Acme\UserBundle\Entity\User
+        service:
+            user_manager: pugx_user_manager
 ```
 
 **Note:**
@@ -179,36 +180,39 @@ In fact is the discriminator that has responsibility to get the user class depen
 
 ### 5. Configure the PUGXMultiUserBundle
 
-``` yaml
-# Acme/UserBundle/Resources/config/config.yml
+```yaml
 
-pugx_multi_user:
-  users:
-    user_one:
-        entity: 
-          class: Acme\UserBundle\Entity\UserOne
-#          factory: 
-        registration:
-          form: 
-            type: Acme\UserBundle\Form\Type\RegistrationUserOneFormType
-            name: fos_user_registration_form
-            validation_groups:  [Registration, Default]
-          template: AcmeUserBundle:Registration:user_one.form.html.twig
-        profile:
-          form:
-            type: Acme\UserBundle\Form\Type\ProfileUserOneFormType
-            name: fos_user_profile_form
-            validation_groups:  [Profile, Default] 
-    user_two:
-        entity: 
-          class: Acme\UserBundle\Entity\UserTwo
-        registration:
-          form: 
-            type: Acme\UserBundle\Form\Type\RegistrationUserTwoFormType
-          template: AcmeUserBundle:Registration:user_two.form.html.twig
-        profile:
-          form: 
-            type: Acme\UserBundle\Form\Type\ProfileUserTwoFormType
+    # Acme/UserBundle/Resources/config/config.yml
+    
+    pugx_multi_user:
+      users:
+        user_one:
+            entity: 
+              class: Acme\UserBundle\Entity\UserOne
+    #          factory: 
+            registration:
+              form: 
+                type: Acme\UserBundle\Form\Type\RegistrationUserOneFormType
+                name: fos_user_registration_form
+                validation_groups:  [Registration, Default]
+              template: AcmeUserBundle:Registration:user_one.form.html.twig
+            profile:
+              form:
+                type: Acme\UserBundle\Form\Type\ProfileUserOneFormType
+                name: fos_user_profile_form
+                validation_groups:  [Profile, Default]
+    #       options- is optional for passing array of options to templates
+            options:            
+        user_two:
+            entity: 
+              class: Acme\UserBundle\Entity\UserTwo
+            registration:
+              form: 
+                type: Acme\UserBundle\Form\Type\RegistrationUserTwoFormType
+              template: AcmeUserBundle:Registration:user_two.form.html.twig
+            profile:
+              form: 
+                type: Acme\UserBundle\Form\Type\ProfileUserTwoFormType
 ```
 
 
@@ -236,41 +240,43 @@ user_two_registration:
 RegistrationUserOneController
 
 ``` php
-<?php
 
-namespace Acme\UserBundle\Controller;
+    <?php
 
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+    namespace Acme\UserBundle\Controller;
 
-class RegistrationUserOneController extends Controller
-{
-    public function registerAction()
+    use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+
+        class RegistrationUserOneController extends Controller
     {
-        return $this->container
+        public function registerAction()
+        {
+            return $this->container
                     ->get('pugx_multi_user.registration_manager')
                     ->register('Acme\UserBundle\Entity\UserOne');
+        }
     }
-}
 ```
 
 RegistrationUserTwoController
 
 ``` php
-<?php
 
-namespace Acme\UserBundle\Controller;
+    <?php
 
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+    namespace Acme\UserBundle\Controller;
 
-class RegistrationUserTwoController extends Controller
-{
-    public function registerAction()
+    use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+
+    class RegistrationUserTwoController extends Controller
     {
-        return $this->container
+        public function registerAction()
+        {
+            return $this->container
                     ->get('pugx_multi_user.registration_manager')
                     ->register('Acme\UserBundle\Entity\UserTwo');
+        }
     }
-}
 ```
 
 
@@ -281,41 +287,89 @@ class RegistrationUserTwoController extends Controller
 something like this, if you are extending fosub
 
 ```
-{% extends "FOSUserBundle::layout.html.twig" %}
 
-{% block fos_user_content %}
-    {% trans_default_domain 'FOSUserBundle' %}
+    {% extends "FOSUserBundle::layout.html.twig" %}
 
-    <form action="{{ path('user_one_registration') }}" {{ form_enctype(form) }} method="POST">
+    {% block fos_user_content %}
+        {% trans_default_domain 'FOSUserBundle' %}
+
+        <form action="{{ path('user_one_registration') }}" {{ form_enctype(form) }} method="POST">
         {{ form_widget(form) }}
         <div>
             <input type="submit" value="{{ 'registration.submit'|trans }}" />
         </div>
     </form>
-{% endblock fos_user_content %}
+    {% endblock fos_user_content %}
 ```
+
+### 7. Overriding forms
 
 **Note:**
 
 > For now only registration and profile form factories are wrapped; 
-if you need creat a custom FormType you have to inject the discriminator.
+if you need to create a custom FormType you have to inject the discriminator.
 
-### 7. Using the User Manager
+**Overriding FOS\UserBundle\Form\Type\RegistrationFormType, FOS\UserBundle\Form\Type\ProfileFormType forms**
+
+You can override these forms as described in the FOSUserBundle documentation if you do __NOT__ use the `options:` option in the `pugx_multi_user:` section of `config.yml`.  If you intend to override those forms and are using  the `options:` option in the `pugx_multi_user:` section of `config.yml`, you __MUST__ instead override **PUGX\MultiUserBundle\Form\RegistrationFormType** and/or **PUGX\MultiUserBundle\Form\ProfileFormType**.
+
+
+```php
+
+    use PUGX\MultiUserBundle\Form\RegistrationFormType as BaseType;
+
+    class SomeFormType extends BaseType
+    {
+    ...
+    }
+```
+
+The options you configure in `config.yml` become available with `$this->options` in your new form.  For example:
+
+if `config.yml` contains:
+
+```yaml
+
+    pugx_multi_user:
+       user: user_one
+            options:
+                option1: true
+                option2: false
+```
+
+Then in your form you can use `$this->options['option1']` to retrieve `true`. Here's an example from a form type's listener:
+
+```php
+
+        $builder->addEventListener(FormEvents::PRE_SET_DATA,
+            function (FormEvent $event) {
+            $form = $event->getForm();
+            if ($this->options['option1']) {
+                $form->add('field1');
+            };
+            if ($this->options['option2']) {
+                $form->add('field2');
+            };
+        });
+```
+
+### 8. Using the User Manager
 
 Creating a new UserOne:
 
 ``` php
-$discriminator = $this->container->get('pugx_user.manager.user_discriminator');
-$discriminator->setClass('Acme\UserBundle\Entity\UserOne');
 
-$userManager = $this->container->get('pugx_user_manager');
+    $discriminator = $this->container->get('pugx_user.manager.user_discriminator');
+    $discriminator->setClass('Acme\UserBundle\Entity\UserOne');
 
-$userOne = $userManager->createUser();
+    $userManager = $this->container->get('pugx_user_manager');
 
-$userOne->setUsername('admin');
-$userOne->setEmail('admin@mail.com');
-$userOne->setPlainPassword('123456');
-$userOne->setEnabled(true);
+    $userOne = $userManager->createUser();
 
-$userManager->updateUser($userOne, true);
+    $userOne->setUsername('admin');
+    $userOne->setEmail('admin@mail.com');
+    $userOne->setPlainPassword('123456');
+    $userOne->setEnabled(true);
+
+    $userManager->updateUser($userOne, true);
 ```

--- a/Tests/Controller/ProfileManagerTest.php
+++ b/Tests/Controller/ProfileManagerTest.php
@@ -2,9 +2,9 @@
 
 namespace PUGX\MultiUserBundle\Tests\Controller;
 
-use PUGX\MultiUserBundle\Controller\RegistrationManager;
+use PUGX\MultiUserBundle\Controller\ProfileManager;
 
-class RegistrationManagerTest extends \PHPUnit_Framework_TestCase
+class ProfileManagerTest extends \PHPUnit_Framework_TestCase
 {
     public function setUp()
     {
@@ -14,7 +14,7 @@ class RegistrationManagerTest extends \PHPUnit_Framework_TestCase
         $this->container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerInterface')
                 ->disableOriginalConstructor()->getMock();
 
-        $this->controller = $this->getMockBuilder('FOS\UserBundle\Controller\RegistrationController')
+        $this->controller = $this->getMockBuilder('FOS\UserBundle\Controller\ProfileController')
                 ->disableOriginalConstructor()->getMock();
 
         $this->formFactory = $this->getMockBuilder('PUGX\MultiUserBundle\Form\FormFactory')
@@ -35,7 +35,7 @@ class RegistrationManagerTest extends \PHPUnit_Framework_TestCase
         $this->formView = $this->getMockBuilder('Symfony\Component\Form\FormView')
                 ->disableOriginalConstructor()->getMock();
 
-        $this->userManager = new RegistrationManager($this->discriminator, $this->container, $this->controller, $this->formFactory);
+        $this->userManager = new ProfileManager($this->discriminator, $this->container, $this->controller, $this->formFactory);
     }
 
     public function common()
@@ -57,35 +57,35 @@ class RegistrationManagerTest extends \PHPUnit_Framework_TestCase
                 ->will($this->returnValue($this->request));
     }
 
-    public function testRegisterReturnRedirectResponse()
+    public function testProfileReturnRedirectResponse()
     {
         $this->common();
 
         $this->controller
                 ->expects($this->exactly(1))
-                ->method('registerAction')
+                ->method('editAction')
                 ->with($this->request)
                 ->will($this->returnValue($this->redirectResponse));
 
-        $result = $this->userManager->register('MyUser');
+        $result = $this->userManager->edit('MyUser');
 
         $this->assertSame($result, $this->redirectResponse);
     }
 
-    public function testRegisterReturnDefaultTemplate()
+    public function testProfileReturnDefaultTemplate()
     {
         $this->common();
 
         $this->controller
                 ->expects($this->exactly(1))
-                ->method('registerAction')
+                ->method('editAction')
                 ->with($this->request)
                 ->will($this->returnValue(null));
 
         $this->discriminator
                 ->expects($this->exactly(1))
                 ->method('getTemplate')
-                ->with('registration')
+                ->with('profile')
                 ->will($this->returnValue(null));
 
         $this->formFactory
@@ -102,31 +102,31 @@ class RegistrationManagerTest extends \PHPUnit_Framework_TestCase
         $this->twig
                 ->expects($this->exactly(1))
                 ->method('renderResponse')
-                ->with('FOSUserBundle:Registration:register.html.twig', array('form' => $this->formView, 'templates' => array()));
+                ->with('FOSUserBundle:Profile:edit.html.twig', array('form' => $this->formView, 'templates' => array()));
 
         $this->form
                 ->expects($this->exactly(1))
                 ->method('createView')
                 ->will($this->returnValue($this->formView));
 
-        $result = $this->userManager->register('MyUser');
+        $result = $this->userManager->edit('MyUser');
     }
 
-    public function testRegisterReturnSpecificTemplate()
+    public function testProfileReturnSpecificTemplate()
     {
         $this->common();
 
         $this->controller
                 ->expects($this->exactly(1))
-                ->method('registerAction')
+                ->method('editAction')
                 ->with($this->request)
                 ->will($this->returnValue(null));
 
         $this->discriminator
                 ->expects($this->exactly(1))
                 ->method('getTemplate')
-                ->with('registration')
-                ->will($this->returnValue('PUGXMultiUserBundle:Registration:register.html.twig'));
+                ->with('profile')
+                ->will($this->returnValue('PUGXMultiUserBundle:Profile:edit.html.twig'));
 
         $this->formFactory
                 ->expects($this->exactly(1))
@@ -142,13 +142,13 @@ class RegistrationManagerTest extends \PHPUnit_Framework_TestCase
         $this->twig
                 ->expects($this->exactly(1))
                 ->method('renderResponse')
-                ->with('PUGXMultiUserBundle:Registration:register.html.twig', array('form' => $this->formView, 'templates' => array()));
+                ->with('PUGXMultiUserBundle:Profile:edit.html.twig', array('form' => $this->formView, 'templates' => array()));
 
         $this->form
                 ->expects($this->exactly(1))
                 ->method('createView')
                 ->will($this->returnValue($this->formView));
 
-        $result = $this->userManager->register('MyUser', $templates = array());
+        $result = $this->userManager->edit('MyUser', $templates = array());
     }
 }

--- a/Tests/Model/UserDiscriminatorTest.php
+++ b/Tests/Model/UserDiscriminatorTest.php
@@ -68,7 +68,7 @@ class UserDiscriminatorTest extends \PHPUnit_Framework_TestCase
                 ),
                 'template' => 'AcmeUserBundle:Profile:user_two.form.html.twig'
             ),
-            'options' => array()
+            'options' => array('option1' => true)
         );
         
         $this->parameters = array('user_one' => $userParameters, 'user_two' => $anotherUserParameters);
@@ -125,6 +125,12 @@ class UserDiscriminatorTest extends \PHPUnit_Framework_TestCase
     {  
         $this->discriminator->setClass('PUGX\MultiUserBundle\Tests\Stub\AnotherUser');        
         $this->assertEquals('PUGX\MultiUserBundle\Tests\Stub\AnotherUser', $this->discriminator->getClass());
+    }
+
+    public function testGetUserOptions()
+    {
+        $this->discriminator->setClass('PUGX\MultiUserBundle\Tests\Stub\AnotherUser');
+        $this->assertEquals(array('option1' => true), $this->discriminator->getUserOptions());
     }
     
     public function testSetClassPersist() 

--- a/Tests/Model/UserDiscriminatorTest.php
+++ b/Tests/Model/UserDiscriminatorTest.php
@@ -44,7 +44,7 @@ class UserDiscriminatorTest extends \PHPUnit_Framework_TestCase
                 ),
                 'template' => 'AcmeUserBundle:Profile:user_two.form.html.twig'
             ),
-            'options' => []
+            'options' => array()
         );
 
         $anotherUserParameters = array(
@@ -68,7 +68,7 @@ class UserDiscriminatorTest extends \PHPUnit_Framework_TestCase
                 ),
                 'template' => 'AcmeUserBundle:Profile:user_two.form.html.twig'
             ),
-            'options' => []
+            'options' => array()
         );
         
         $this->parameters = array('user_one' => $userParameters, 'user_two' => $anotherUserParameters);
@@ -98,7 +98,7 @@ class UserDiscriminatorTest extends \PHPUnit_Framework_TestCase
                     'validation_groups' => array('Profile', 'Default')
                 )
             ),
-            'options' => []
+            'options' => array()
         );
         
         $parameters     = array('user' => $userParameters);

--- a/Tests/Model/UserDiscriminatorTest.php
+++ b/Tests/Model/UserDiscriminatorTest.php
@@ -43,7 +43,8 @@ class UserDiscriminatorTest extends \PHPUnit_Framework_TestCase
                     'validation_groups' => array('Profile', 'Default')
                 ),
                 'template' => 'AcmeUserBundle:Profile:user_two.form.html.twig'
-            )
+            ),
+            'options' => []
         );
 
         $anotherUserParameters = array(
@@ -66,7 +67,8 @@ class UserDiscriminatorTest extends \PHPUnit_Framework_TestCase
                     'validation_groups' => array('Profile', 'Default')
                 ),
                 'template' => 'AcmeUserBundle:Profile:user_two.form.html.twig'
-            )
+            ),
+            'options' => []
         );
         
         $this->parameters = array('user_one' => $userParameters, 'user_two' => $anotherUserParameters);
@@ -95,7 +97,8 @@ class UserDiscriminatorTest extends \PHPUnit_Framework_TestCase
                 'options' => array(
                     'validation_groups' => array('Profile', 'Default')
                 )
-            )
+            ),
+            'options' => []
         );
         
         $parameters     = array('user' => $userParameters);

--- a/Tests/Model/UserDiscriminatorTest.php
+++ b/Tests/Model/UserDiscriminatorTest.php
@@ -13,16 +13,17 @@ use Symfony\Component\Form\FormFactoryInterface;
 
 class UserDiscriminatorTest extends \PHPUnit_Framework_TestCase
 {
+
     public function setUp()
     {
         $this->session = $this->getMockBuilder('Symfony\Component\HttpFoundation\Session\Session')->disableOriginalConstructor()->getMock();
-        
-        $this->event = $this->getMockBuilder('Symfony\Component\Security\Http\Event\InteractiveLoginEvent')->disableOriginalConstructor()->getMock();       
-        $this->token = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken')->disableOriginalConstructor()->getMock();      
-        $this->user = new User();  
-        $this->userInvalid = $this->getMockBuilder('InvalidUser')->disableOriginalConstructor()->getMock();  
+
+        $this->event       = $this->getMockBuilder('Symfony\Component\Security\Http\Event\InteractiveLoginEvent')->disableOriginalConstructor()->getMock();
+        $this->token       = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken')->disableOriginalConstructor()->getMock();
+        $this->user        = new User();
+        $this->userInvalid = $this->getMockBuilder('InvalidUser')->disableOriginalConstructor()->getMock();
         $this->userFactory = $this->getMockBuilder('PUGX\MultiUserBundle\Model\UserFactoryInterface')->disableOriginalConstructor()->getMock();
-                
+
         $userParameters = array(
             'entity' => array(
                 'class' => 'PUGX\MultiUserBundle\Tests\Stub\User',
@@ -44,7 +45,7 @@ class UserDiscriminatorTest extends \PHPUnit_Framework_TestCase
                 ),
                 'template' => 'AcmeUserBundle:Profile:user_two.form.html.twig'
             ),
-            'options' => array()
+            'options' => array('option1' => true)
         );
 
         $anotherUserParameters = array(
@@ -70,17 +71,18 @@ class UserDiscriminatorTest extends \PHPUnit_Framework_TestCase
             ),
             'options' => array('option1' => true)
         );
-        
+
         $this->parameters = array('user_one' => $userParameters, 'user_two' => $anotherUserParameters);
-        
-        $this->discriminator = new UserDiscriminator($this->session, $this->parameters);
+
+        $this->discriminator = new UserDiscriminator($this->session,
+            $this->parameters);
     }
-        
+
     /**
      * @expectedException \LogicException
      */
     public function testBuildException()
-    {        
+    {
         $userParameters = array(
             'entity' => array(
                 'class' => 'FakeUser',
@@ -100,127 +102,152 @@ class UserDiscriminatorTest extends \PHPUnit_Framework_TestCase
             ),
             'options' => array()
         );
-        
-        $parameters     = array('user' => $userParameters);
-        $discriminator  = new UserDiscriminator($this->session, $parameters);
+
+        $parameters    = array('user' => $userParameters);
+        $discriminator = new UserDiscriminator($this->session, $parameters);
     }
-    
+
     /**
      * 
      */
-    public function testGetClasses() 
+    public function testGetClasses()
     {
-        $this->assertEquals(array('PUGX\MultiUserBundle\Tests\Stub\User', 'PUGX\MultiUserBundle\Tests\Stub\AnotherUser'), $this->discriminator->getClasses());
+        $this->assertEquals(array('PUGX\MultiUserBundle\Tests\Stub\User', 'PUGX\MultiUserBundle\Tests\Stub\AnotherUser'),
+            $this->discriminator->getClasses());
     }
-    
+
     /**
      * @expectedException \LogicException
      */
-    public function testSetClassException() 
+    public function testSetClassException()
     {
         $this->discriminator->setClass('ArbitaryClass');
     }
-    
-    public function testGetClass() 
-    {  
-        $this->discriminator->setClass('PUGX\MultiUserBundle\Tests\Stub\AnotherUser');        
-        $this->assertEquals('PUGX\MultiUserBundle\Tests\Stub\AnotherUser', $this->discriminator->getClass());
+
+    public function testGetClass()
+    {
+        $this->discriminator->setClass('PUGX\MultiUserBundle\Tests\Stub\AnotherUser');
+        $this->assertEquals('PUGX\MultiUserBundle\Tests\Stub\AnotherUser',
+            $this->discriminator->getClass());
     }
 
     public function testGetUserOptions()
     {
         $this->discriminator->setClass('PUGX\MultiUserBundle\Tests\Stub\AnotherUser');
-        $this->assertEquals(array('option1' => true), $this->discriminator->getUserOptions());
+        $this->assertEquals(array('option1' => true),
+            $this->discriminator->getUserOptions());
     }
-    
-    public function testSetClassPersist() 
-    {        
-        $this->session->expects($this->exactly(1))->method('set')->with(UserDiscriminator::SESSION_NAME, 'PUGX\MultiUserBundle\Tests\Stub\User');        
-        $this->discriminator->setClass('PUGX\MultiUserBundle\Tests\Stub\User', true);
-    }
-    
-    public function testGetClassDefault() 
+
+    public function testSetClassPersist()
     {
-        $this->session->expects($this->exactly(1))->method('get')->with(UserDiscriminator::SESSION_NAME, null)->will($this->onConsecutiveCalls(null));        
-        $this->assertEquals('PUGX\MultiUserBundle\Tests\Stub\User', $this->discriminator->getClass());
+        $this->session->expects($this->exactly(1))->method('set')->with(UserDiscriminator::SESSION_NAME,
+            'PUGX\MultiUserBundle\Tests\Stub\User');
+        $this->discriminator->setClass('PUGX\MultiUserBundle\Tests\Stub\User',
+            true);
     }
-    
-    public function testGetClassStored() 
+
+    public function testGetClassDefault()
     {
-        $this->session->expects($this->exactly(1))->method('get')->with(UserDiscriminator::SESSION_NAME, null)->will($this->onConsecutiveCalls('PUGX\MultiUserBundle\Tests\Stub\AnotherUser'));
-        $this->assertEquals('PUGX\MultiUserBundle\Tests\Stub\AnotherUser', $this->discriminator->getClass());
+        $this->session->expects($this->exactly(1))->method('get')->with(UserDiscriminator::SESSION_NAME,
+            null)->will($this->onConsecutiveCalls(null));
+        $this->assertEquals('PUGX\MultiUserBundle\Tests\Stub\User',
+            $this->discriminator->getClass());
     }
-    
+
+    public function testGetClassStored()
+    {
+        $this->session->expects($this->exactly(1))->method('get')->with(UserDiscriminator::SESSION_NAME,
+            null)->will($this->onConsecutiveCalls('PUGX\MultiUserBundle\Tests\Stub\AnotherUser'));
+        $this->assertEquals('PUGX\MultiUserBundle\Tests\Stub\AnotherUser',
+            $this->discriminator->getClass());
+    }
+
     public function testCreateUser()
-    {        
+    {
         $expected = new AnotherUser();
-        $this->session->expects($this->exactly(0))->method('get');   
-        
+        $this->session->expects($this->exactly(0))->method('get');
+
         $this->discriminator->setClass('PUGX\MultiUserBundle\Tests\Stub\AnotherUser');
         $result = $this->discriminator->createUser();
         $this->assertEquals($expected, $result);
     }
-    
+
     public function testGetUserFactory()
     {
         $this->discriminator->setClass('PUGX\MultiUserBundle\Tests\Stub\AnotherUser');
         $result = $this->discriminator->getUserFactory();
-        $this->assertEquals('PUGX\MultiUserBundle\Tests\Stub\CustomUserFactory', $result);
+        $this->assertEquals('PUGX\MultiUserBundle\Tests\Stub\CustomUserFactory',
+            $result);
     }
-    
+
     public function testGetFormTypeRegistration()
     {
         $this->discriminator->setClass('PUGX\MultiUserBundle\Tests\Stub\User');
         $result = $this->discriminator->getFormType('registration');
-        $this->assertEquals('PUGX\MultiUserBundle\Tests\Stub\UserRegistrationForm', get_class($result));
+        $this->assertEquals('PUGX\MultiUserBundle\Tests\Stub\UserRegistrationForm',
+            get_class($result));
     }
-    
+
+    public function testGetFormTypeRegistrationWithOptions()
+    {
+        $form = new UserRegistrationForm('PUGX\MultiUserBundle\Tests\Stub\User');
+        $reflectForm = new \ReflectionClass($form);
+        $reflectOptions = $reflectForm->getProperty('options');
+        $reflectOptions->setAccessible(true);
+
+        $this->discriminator->setClass('PUGX\MultiUserBundle\Tests\Stub\User');
+        $result             = $this->discriminator->getFormType('registration');
+        $this->assertEquals(array('option1' => true), $reflectOptions->getValue($result));
+        }
+
     public function testGetFormTypeProfile()
     {
         $this->discriminator->setClass('PUGX\MultiUserBundle\Tests\Stub\User');
         $result = $this->discriminator->getFormType('profile');
-        $this->assertEquals('PUGX\MultiUserBundle\Tests\Stub\UserProfileForm', get_class($result));
+        $this->assertEquals('PUGX\MultiUserBundle\Tests\Stub\UserProfileForm',
+            get_class($result));
     }
-    
+
     public function testGetFormNameRegistration()
     {
         $this->discriminator->setClass('PUGX\MultiUserBundle\Tests\Stub\AnotherUser');
         $result = $this->discriminator->getFormName('registration');
         $this->assertEquals('fos_user_my_registration_form', $result);
     }
-    
+
     public function testGetFormNameProfile()
     {
         $this->discriminator->setClass('PUGX\MultiUserBundle\Tests\Stub\User');
         $result = $this->discriminator->getFormName('profile');
         $this->assertEquals('fos_user_profile_form', $result);
     }
-    
+
     public function testGetValidationGroupsRegistration()
     {
         $this->discriminator->setClass('PUGX\MultiUserBundle\Tests\Stub\User');
         $result = $this->discriminator->getFormValidationGroups('registration');
         $this->assertEquals(array('Registration', 'Default'), $result);
     }
-    
+
     public function testGetValidationGroupsRegistrationCustom()
     {
         $this->discriminator->setClass('PUGX\MultiUserBundle\Tests\Stub\AnotherUser');
         $result = $this->discriminator->getFormValidationGroups('registration');
         $this->assertEquals(array('MyRegistration', 'Default'), $result);
     }
-    
+
     public function testGetValidationGroupsProfile()
     {
         $this->discriminator->setClass('PUGX\MultiUserBundle\Tests\Stub\User');
         $result = $this->discriminator->getFormValidationGroups('profile');
         $this->assertEquals(array('Profile', 'Default'), $result);
     }
-    
+
     public function testGetRegistrationTemplate()
     {
         $this->discriminator->setClass('PUGX\MultiUserBundle\Tests\Stub\User');
         $result = $this->discriminator->getTemplate('registration');
-        $this->assertEquals('AcmeUserBundle:Registration:user_one.form.html.twig', $result);
+        $this->assertEquals('AcmeUserBundle:Registration:user_one.form.html.twig',
+            $result);
     }
 }

--- a/Tests/Stub/UserProfileForm.php
+++ b/Tests/Stub/UserProfileForm.php
@@ -4,8 +4,17 @@ namespace PUGX\MultiUserBundle\Tests\Stub;
 
 class UserProfileForm
 {
+    protected $class;
+    protected $options;
+
+    public function __construct($class, $options = null)
+    {
+        $this->class = $class;
+        $this->options = $options;
+    }
+
     public function getName()
     {
-        return "form_name";
+        return 'form_name';
     }
 }

--- a/Tests/Stub/UserRegistrationForm.php
+++ b/Tests/Stub/UserRegistrationForm.php
@@ -4,6 +4,15 @@ namespace PUGX\MultiUserBundle\Tests\Stub;
 
 class UserRegistrationForm
 {
+    private $class;
+    private $options;
+
+    public function __construct($class, $options = null)
+    {
+        $this->class   = $class;
+        $this->options = $options;
+    }
+
     public function getName()
     {
         return "form_name";

--- a/Tests/Stub/UserRegistrationForm.php
+++ b/Tests/Stub/UserRegistrationForm.php
@@ -4,17 +4,17 @@ namespace PUGX\MultiUserBundle\Tests\Stub;
 
 class UserRegistrationForm
 {
-    private $class;
-    private $options;
+    protected $class;
+    protected $options;
 
     public function __construct($class, $options = null)
     {
-        $this->class   = $class;
+        $this->class = $class;
         $this->options = $options;
     }
 
     public function getName()
     {
-        return "form_name";
+        return 'form_name';
     }
 }


### PR DESCRIPTION
This PR adds the ability to send `config.yml` options to registration and profile forms.  It also adds the ability to add business logic to registration and profile controllers.  These controllers have ready access to the container, making it possible to create an array of templates based on a set of conditions. The templates array is then passed to the registration & profile templates.  See the updated documentation for details.
